### PR TITLE
Added a bigger timeout for the Ktor client

### DIFF
--- a/solver/src/main/kotlin/pro/schmid/sbbtsp/repositories/ConnectionsRepository.kt
+++ b/solver/src/main/kotlin/pro/schmid/sbbtsp/repositories/ConnectionsRepository.kt
@@ -1,5 +1,6 @@
 package pro.schmid.sbbtsp.repositories
 
+import io.ktor.util.error
 import kotlinx.coroutines.*
 import org.slf4j.LoggerFactory
 import pro.schmid.sbbtsp.db.Database
@@ -21,7 +22,12 @@ class ConnectionsRepository(
         }
 
         logger.debug("($from, $to): Downloading...")
-        val allConnections = api.downloadConnections(from, to)
+        val allConnections = try {
+            api.downloadConnections(from, to)
+        } catch (e: Exception) {
+            logger.error(e)
+            throw e
+        }
         logger.debug("($from, $to): Downloaded")
 
         val allTimes = allConnections.mapNotNull {
@@ -57,7 +63,7 @@ class ConnectionsRepository(
         allStations.forEach {
             createStation(it)
         }
-        
+
         val fromNetwork = database.createConnection(
             from,
             to,

--- a/solver/src/main/kotlin/pro/schmid/sbbtsp/transportapi/TransportApi.kt
+++ b/solver/src/main/kotlin/pro/schmid/sbbtsp/transportapi/TransportApi.kt
@@ -16,6 +16,9 @@ class TransportApi {
             }
             serializer = KotlinxSerializer(json)
         }
+        engine {
+            requestTimeout = 30000
+        }
     }
 
     suspend fun downloadConnections(from: String, to: String): List<Connection> {


### PR DESCRIPTION
Sometimes for complex queries the Transport API takes a long time to respond.

For example http://transport.opendata.ch/v1/connections?from=8577737&to=8509778&date=2020-07-01&time=07%3A00&limit=16

This increases the timeout to 30s to help having better results.